### PR TITLE
Add lower dependency on aeson package.

### DIFF
--- a/hasbolt-extras.cabal
+++ b/hasbolt-extras.cabal
@@ -48,7 +48,7 @@ library
                      , Database.Bolt.Extras.Graph.Internal.GraphQuery
                   
   build-depends:       base >=4.7 && <5
-                     , aeson
+                     , aeson >= 1.3.0.0
                      , aeson-casing
                      , containers
                      , free


### PR DESCRIPTION
Set a ower bound for aeson package, as otherwise hackage
(and any other tool that doesn't use stack) may require
select version that is too low. Then the build is failing, see

  http://hackage.haskell.org/package/hasbolt-extras-0.0.0.17/reports/3

as an example of failure.